### PR TITLE
Adding functionality for the --strip-dot-git flag

### DIFF
--- a/features/install/git.feature
+++ b/features/install/git.feature
@@ -197,3 +197,12 @@ Feature: cli/install/git
     When I run `librarian-puppet install`
     Then the exit status should be 0
     And the output should contain "Dependency 'puppetlabs-stdlib' duplicated for module, merging"
+
+  Scenario: Omit the .git directory when passed --strip-dot-git
+    Given a file named "Puppetfile" with:
+    """
+    mod 'puppetlabs-stdlib',
+      :git => 'git://github.com/puppetlabs/puppetlabs-stdlib.git'
+    """
+    When I run `librarian-puppet install --strip-dot-git`
+    Then a directory "modules/stdlib/.git" should not exist

--- a/lib/librarian/puppet/source/git.rb
+++ b/lib/librarian/puppet/source/git.rb
@@ -37,6 +37,11 @@ module Librarian
             raise Error, "Could not checkout #{uri}#{" at #{sha}" unless sha.nil?}: #{e}"
           end
 
+          if environment.config_db["install.strip-dot-git"] == "1"
+            dot_git = filesystem_path.join(".git")
+            dot_git.rmtree if dot_git.directory?
+          end
+
           cache_in_vendor(repository.path) if environment.vendor?
         end
 


### PR DESCRIPTION
Mirroring https://github.com/rodjek/librarian-puppet/pull/332

r? @kitchen
